### PR TITLE
Fix redis_url reference for semantic router

### DIFF
--- a/demos/workbench/chat_app.py
+++ b/demos/workbench/chat_app.py
@@ -121,7 +121,7 @@ class ChatApp:
         }
 
         # Init semantic router
-        self.semantic_router = SemanticRouter.from_yaml("demos/workbench/router.yaml", overwrite=True)
+        self.semantic_router = SemanticRouter.from_yaml("demos/workbench/router.yaml", redis_url=self.redis_url, overwrite=True)
 
         # Init chat history if use_chat_history is True
         if self.use_chat_history:


### PR DESCRIPTION
When initializing the semantic router, the redis_url was not passed in, causing it to default to localhost:6379